### PR TITLE
Use validate credentials before attempting to login

### DIFF
--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -177,6 +177,7 @@ class Login extends BaseLogin
             ->submit('authenticate');
     }
 
+    /** @param array<string, mixed> $credentials */
     protected function validateCredentials(array $credentials): bool
     {
         $provider = Filament::auth()->getProvider();

--- a/src/Http/Livewire/Auth/Login.php
+++ b/src/Http/Livewire/Auth/Login.php
@@ -102,12 +102,11 @@ class Login extends BaseLogin
 
         $request = request()->merge($data);
 
-        if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
+        if (! $this->validateCredentials($this->getCredentialsFromFormData($data))) {
             $this->throwFailureValidationException();
         }
 
         return $this->loginPipeline($request)->then(function (Request $request) use ($data) {
-
             if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
                 $this->throwFailureValidationException();
             }
@@ -176,5 +175,13 @@ class Login extends BaseLogin
             ->color('info')
             ->label(__('filament-panels::pages/auth/login.form.actions.authenticate.label'))
             ->submit('authenticate');
+    }
+
+    protected function validateCredentials(array $credentials): bool
+    {
+        $provider = Filament::auth()->getProvider();
+        $user = $provider->retrieveByCredentials($credentials);
+
+        return $user && $provider->validateCredentials($user, $credentials);
     }
 }


### PR DESCRIPTION
Previously we tried to check for correct user credentials by using `attempt()` before the pipeline. But this method actually logins the user before going through the pipeline. This code fixes that. 