### PR TITLE
UX improvements

### DIFF
--- a/resources/views/auth/login-two-factor.blade.php
+++ b/resources/views/auth/login-two-factor.blade.php
@@ -3,14 +3,18 @@
         {{ __('Authenticate with your code') }}
     </h2>
     @if ($twoFactorType === 'email' || $twoFactorType === 'phone')
-        <div wire:poll.5s>
-            {{ $this->resend }}
-        </div>
+    <div wire:poll.5s>
+        {{ $this->resend }}
+    </div>
     @endif
     <form method="POST" action="{{ route('two-factor.login') }}" class="space-y-8">
 
         @csrf
         {{ $this->form }}
+
+        <div style="display: none">
+            <input type="text" id="recovery_code" wire:model="recovery_code" name="recovery_code" value="">
+        </div>
 
         <div class="flex items-center justify-between mt-6">
             <x-filament::button type="submit" class="w-full" color="primary">

--- a/src/Http/Livewire/Auth/LoginTwoFactor.php
+++ b/src/Http/Livewire/Auth/LoginTwoFactor.php
@@ -68,8 +68,8 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
             ->color('primary')
             ->extraAttributes(['class' => 'w-full text-xs'])
             ->link()
-            ->disabled(fn () => ! $this->canResend())
-            ->action(fn () => $this->handleResend());
+            ->disabled(fn() => ! $this->canResend())
+            ->action(fn() => $this->handleResend());
     }
 
     public function handleResend(): void
@@ -126,7 +126,10 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
         return [
             TextInput::make('code')
                 ->required()
-                ->extraInputAttributes(['name' => 'code'])
+                ->extraInputAttributes([
+                    'name' => 'code',
+                    'autocomplete' => 'one-time-code',
+                ])
                 ->label(__('Code')),
             TextInput::make('recovery_code')
                 ->extraInputAttributes(['name' => 'recovery_code'])

--- a/src/Http/Livewire/Auth/LoginTwoFactor.php
+++ b/src/Http/Livewire/Auth/LoginTwoFactor.php
@@ -136,7 +136,7 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
                     'name' => 'code',
                     'autocomplete' => 'one-time-code',
                 ])
-                ->afterStateUpdated(fn(Set $set, ?string $state) => $set('recovery_code', $state))
+                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('recovery_code', $state))
                 ->live(),
         ];
     }

--- a/src/Http/Livewire/Auth/LoginTwoFactor.php
+++ b/src/Http/Livewire/Auth/LoginTwoFactor.php
@@ -9,6 +9,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Set;
 use Filament\Notifications\Notification;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use Filament\Pages\Page;
@@ -33,6 +34,10 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
     public mixed $challengedUser = null;
 
     public ?string $twoFactorType = null;
+
+    public ?string $code = null;
+
+    public ?string $recovery_code = null;
 
     #[Reactive]
     public int $lastResendTime = 0;
@@ -125,15 +130,14 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
     {
         return [
             TextInput::make('code')
+                ->label(__('Code'))
                 ->required()
                 ->extraInputAttributes([
                     'name' => 'code',
                     'autocomplete' => 'one-time-code',
                 ])
-                ->label(__('Code')),
-            TextInput::make('recovery_code')
-                ->extraInputAttributes(['name' => 'recovery_code'])
-                ->label(__('Recovery code')),
+                ->afterStateUpdated(fn(Set $set, ?string $state) => $set('recovery_code', $state))
+                ->live(),
         ];
     }
 }

--- a/src/Http/Livewire/Auth/LoginTwoFactor.php
+++ b/src/Http/Livewire/Auth/LoginTwoFactor.php
@@ -68,8 +68,8 @@ class LoginTwoFactor extends Page implements HasActions, HasForms
             ->color('primary')
             ->extraAttributes(['class' => 'w-full text-xs'])
             ->link()
-            ->disabled(fn() => ! $this->canResend())
-            ->action(fn() => $this->handleResend());
+            ->disabled(fn () => ! $this->canResend())
+            ->action(fn () => $this->handleResend());
     }
 
     public function handleResend(): void


### PR DESCRIPTION
This PR adds:

- One Time Code field recognition for browser autocompletion
- Merge code and recovery input, so only one "code" input is shown to user where either 2FA or recovery code can be filled in