### PR TITLE
Fixed: infinity redirect loop when panel path is base url

### DIFF
--- a/src/Http/Middleware/ForceTwoFactor.php
+++ b/src/Http/Middleware/ForceTwoFactor.php
@@ -12,7 +12,7 @@ class ForceTwoFactor
     {
         $user = Filament::auth()->user();
 
-        if ($request->is('*/two-factor') || $request->is('*/logout')) {
+        if ($request->is('*two-factor') || $request->is('*logout')) {
             return $next($request);
         }
 


### PR DESCRIPTION
When the filament panel is on the base url (e.g. localhost) the middleware is causing an infinity loop. Not checking for a prefixed slash fixes this issue and still keeps the same logic when the panel is not on the base url (e.g. localhost/admin)