### PR TITLE
Update TwoFactor.php

### DIFF
--- a/src/Pages/TwoFactor.php
+++ b/src/Pages/TwoFactor.php
@@ -45,6 +45,7 @@ class TwoFactor extends Page implements HasForms
 
     public ?int $twoFactorOptionsCount = null;
 
+    /**@var Model $user */
     public mixed $user = null;
 
     protected static string $view = 'filament-2fa::two-factor';
@@ -252,7 +253,7 @@ class TwoFactor extends Page implements HasForms
                         'name' => 'email',
                         'label' => __('Email'),
                         'default' => $this->user->email,
-                        'rules' => ['required', 'email', Rule::unique('users', 'email')->ignore($this->user->id)],
+                        'rules' => ['required', 'email', Rule::unique($this->user->getTable(), 'email')->ignore($this->user->id)],
                     ];
 
                     break;


### PR DESCRIPTION
Fix: Dynamically get user table name for unique email rule

Previously, the unique email validation rule in the 2FA confirmation form hardcoded the 'users' table name. This caused issues if the actual user model uses a different table (e.g., 'admins', 'members').

This commit updates the `Rule::unique` call in `getConfirmableFields()` to dynamically retrieve the user model's table name using `$this->user->getTable()`. This ensures the validation correctly checks uniqueness against the actual table where user data is stored, improving flexibility and correctness.